### PR TITLE
Disable broken VS automatic package restore

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -14,4 +14,9 @@
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
   </packageSources>
+  <packageRestore>
+    <!-- Automated package restore in VS does not work at this time with
+         this project and it causes build failures. Disable it. -->
+    <add key="automatic" value="false" />
+  </packageRestore>
 </configuration>


### PR DESCRIPTION
Fix the VS build issue without depending on it being disabled globally.

@tmat