### PR TITLE
Support Portable PDB matches without the stamp

### DIFF
--- a/src/Microsoft.DiaSymReader.PortablePdb.Tests/SymReaderTests.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb.Tests/SymReaderTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DiaSymReader.PortablePdb.UnitTests
             bool matches;
             Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, expectedStamp, 1, out matches));
             Assert.True(matches);
-            Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, expectedStamp, -1, out matches));
+            Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, expectedStamp, 12, out matches));
             Assert.False(matches);
             Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, expectedStamp, 2, out matches));
             Assert.False(matches);

--- a/src/Microsoft.DiaSymReader.PortablePdb.Tests/SymReaderTests.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb.Tests/SymReaderTests.cs
@@ -65,6 +65,15 @@ namespace Microsoft.DiaSymReader.PortablePdb.UnitTests
             Assert.Equal(HResult.S_OK, symReader.MatchesModule(anotherGuid, expectedStamp, 1, out matches));
             Assert.False(matches);
 
+            if (portable)
+            {
+                // Verify matching without the timestamp works correctly also
+                Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, 0, -1, out matches));
+                Assert.True(matches);
+                Assert.Equal(HResult.S_OK, symReader.MatchesModule(anotherGuid, 0, -1, out matches));
+                Assert.False(matches);
+            }
+
             // Windows PDB matching ignores the stamp:
             Assert.Equal(HResult.S_OK, symReader.MatchesModule(expectedGuid, anotherStamp, 1, out matches));
             Assert.Equal(!portable, matches);

--- a/src/Microsoft.DiaSymReader.PortablePdb/PortablePdbReader.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/PortablePdbReader.cs
@@ -134,13 +134,16 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         internal bool MatchesModule(Guid guid, uint stamp, int age)
         {
-            if (age != 1)
+            // A valid portable PDB age is always 1.
+            // We also allow the special '-1' value along with zero for the stamp to indicate that the caller isn't able to provide the stamp value
+            if (age != 1 && age != -1)
             {
                 return false;
             }
 
             var id = new BlobContentId(MetadataReader.DebugMetadataHeader.Id);
-            return id.Guid == guid && id.Stamp == stamp;
+
+            return id.Guid == guid && (id.Stamp == stamp || age == -1);
         }
 
         internal MetadataReader MetadataReader

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
@@ -749,6 +749,11 @@ namespace Microsoft.DiaSymReader.PortablePdb
         /// <summary>
         /// Checks whether the id stored in the PDB matches the PDB ID stored in the PE/COFF Debug Directory.
         /// </summary>
+        /// <param name="guid">The GUID portion of the PDB ID from the PE/COFFF debug directory</param>
+        /// <param name="stamp">The timestamp portion of the PDB ID from the PE/COFF debug directory. If the caller 
+        /// doesn't have access to this value, the caller may also pass zero for this value and -1 for the age.</param>
+        /// <param name="age">The age value from the PE/COFF debug directory</param>
+        /// <param name="result">True if the PDB matches the provided PDB ID</param>
         [PreserveSig]
         public int MatchesModule(Guid guid, uint stamp, int age, [MarshalAs(UnmanagedType.Bool)]out bool result)
         {


### PR DESCRIPTION
This PR changes SymReader.MatchesModule to support scenarios where the caller only has access to PDB name/MVID/Age. In these cases, the caller is responsible for passing -1 for age and 0 for the stamp.