### PR TITLE
Fix internal image names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ schedules:
     - main
 
 variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
   - name: _TeamName
     value: Roslyn
   - name: _PublishUsingPipelines
@@ -44,8 +45,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             vmImage: 'windows-latest'
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals 1es.windows-2022
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals 1es-windows-2022
         variables:
         # Only enable publishing in official builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
It should be 1es-windows-2022 instead of 1es.windows-2022.

We can also use the predefined variable for the pool name.

/cc @tmat