### PR TITLE
Update usage of COM interop to `ComWrappers` when targeting .NET 9

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- Opt-in/out repo features -->
@@ -11,7 +11,9 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
     <!-- symreader -->
-    <MicrosoftDiaSymReaderVersion>1.4.0-beta2-21525-04</MicrosoftDiaSymReaderVersion>
+    <MicrosoftDiaSymReaderVersion>2.2.0-beta.24327.1
+
+</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.0.0-beta1.21524.1</MicrosoftDiaSymReaderNativeVersion>
     <!-- CoreFX -->
     <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>

--- a/src/Microsoft.DiaSymReader.PortablePdb/DocumentId.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/DocumentId.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public bool Equals(DocumentId other) => Value == other.Value;
         public override int GetHashCode() => Value.GetHashCode();
-        public override bool Equals(object obj) => obj is DocumentId id && Equals(id);
+        public override bool Equals(object? obj) => obj is DocumentId id && Equals(id);
 
         private object GetDebuggerDisplay() => Value;
     }

--- a/src/Microsoft.DiaSymReader.PortablePdb/IMetadataImport.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/IMetadataImport.cs
@@ -5,15 +5,21 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("7DAC8207-D3AE-4c75-9B67-92801A497D44")]
-    public unsafe interface IMetadataImport
+#if NET9_0_OR_GREATER
+    [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+#else
+    [ComImport]
+#endif
+    public unsafe partial interface IMetadataImport
     {
         [PreserveSig]
         void CloseEnum(uint handleEnum);
@@ -23,15 +29,15 @@ namespace Microsoft.DiaSymReader.PortablePdb
         uint EnumInterfaceImpls(ref uint handlePointerEnum, uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] uint[] arrayImpls, uint countMax);
         uint EnumTypeRefs(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arrayTypeRefs, uint countMax);
         uint FindTypeDefByName(string stringTypeDef, uint tokenEnclosingClass);
-        Guid GetScopeProps(StringBuilder stringName, uint cchName, out uint pchName);
+        Guid GetScopeProps([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] char[] stringName, uint cchName, out uint pchName);
         uint GetModuleFromScope();
 
         void GetTypeDefProps(
             int typeDefinition,
-            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder? qualifiedName,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] char[]? qualifiedName,
             int qualifiedNameBufferLength,
             out int qualifiedNameLength,
-            [MarshalAs(UnmanagedType.U4)] out TypeAttributes attributes,
+            out TypeAttributes attributes,
             out int baseType);
 
         uint GetInterfaceImplProps(uint impl, out uint pointerClass);
@@ -39,11 +45,11 @@ namespace Microsoft.DiaSymReader.PortablePdb
         void GetTypeRefProps(
             int typeReference,
             out int resolutionScope,
-            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder? qualifiedName,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[]? qualifiedName,
             int qualifiedNameBufferLength,
             out int qualifiedNameLength);
 
-        uint ResolveTypeRef(uint tr, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppIScope);
+        uint ResolveTypeRef(uint tr, in Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppIScope);
         uint EnumMembers(ref uint handlePointerEnum, uint cl, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] uint[] arrayMembers, uint countMax);
         uint EnumMembersWithName(ref uint handlePointerEnum, uint cl, string stringName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] uint[] arrayMembers, uint countMax);
         uint EnumMethods(ref uint handlePointerEnum, uint cl, uint* arrayMethods, uint countMax);
@@ -62,10 +68,10 @@ namespace Microsoft.DiaSymReader.PortablePdb
         uint FindMemberRef(uint td, string stringName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] voidPointerSigBlob, uint byteCountSigBlob);
         uint GetMethodProps(uint mb, out uint pointerClass, IntPtr stringMethod, uint cchMethod, out uint pchMethod, IntPtr pdwAttr,
           IntPtr ppvSigBlob, IntPtr pcbSigBlob, IntPtr pulCodeRVA);
-        unsafe uint GetMemberRefProps(uint mr, ref uint ptk, StringBuilder stringMember, uint cchMember, out uint pchMember, out byte* ppvSigBlob);
+        unsafe uint GetMemberRefProps(uint mr, ref uint ptk, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringMember, uint cchMember, out uint pchMember, out byte* ppvSigBlob);
         uint EnumProperties(ref uint handlePointerEnum, uint td, uint* arrayProperties, uint countMax);
         uint EnumEvents(ref uint handlePointerEnum, uint td, uint* arrayEvents, uint countMax);
-        uint GetEventProps(uint ev, out uint pointerClass, StringBuilder stringEvent, uint cchEvent, out uint pchEvent, out uint pdwEventFlags,
+        uint GetEventProps(uint ev, out uint pointerClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringEvent, uint cchEvent, out uint pchEvent, out uint pdwEventFlags,
           out uint ptkEventType, out uint pmdAddOn, out uint pmdRemoveOn, out uint pmdFire,
           [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 11)] uint[] rmdOtherMethod, uint countMax);
         uint EnumMethodSemantics(ref uint handlePointerEnum, uint mb, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] uint[] arrayEventProp, uint countMax);
@@ -81,13 +87,13 @@ namespace Microsoft.DiaSymReader.PortablePdb
             out byte* ppvSig,   // return pointer to signature blob
             out int pcbSig);    // return size of signature
 
-        uint GetModuleRefProps(uint mur, StringBuilder stringName, uint cchName);
+        uint GetModuleRefProps(uint mur, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] char[] stringName, uint cchName);
         uint EnumModuleRefs(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arrayModuleRefs, uint cmax);
         unsafe uint GetTypeSpecFromToken(uint typespec, out byte* ppvSig);
         uint GetNameFromToken(uint tk);
         uint EnumUnresolvedMethods(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arrayMethods, uint countMax);
-        uint GetUserString(uint stk, StringBuilder stringString, uint cchString);
-        uint GetPinvokeMap(uint tk, out uint pdwMappingFlags, StringBuilder stringImportName, uint cchImportName, out uint pchImportName);
+        uint GetUserString(uint stk, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] char[] stringString, uint cchString);
+        uint GetPinvokeMap(uint tk, out uint pdwMappingFlags, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringImportName, uint cchImportName, out uint pchImportName);
         uint EnumSignatures(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arraySignatures, uint cmax);
         uint EnumTypeSpecs(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arrayTypeSpecs, uint cmax);
         uint EnumUserStrings(ref uint handlePointerEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] uint[] arrayStrings, uint cmax);
@@ -96,14 +102,14 @@ namespace Microsoft.DiaSymReader.PortablePdb
         uint EnumCustomAttributes(ref uint handlePointerEnum, uint tk, uint tokenType, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] uint[] arrayCustomAttributes, uint countMax);
         uint GetCustomAttributeProps(uint cv, out uint ptkObj, out uint ptkType, out void* ppBlob);
         uint FindTypeRef(uint tokenResolutionScope, string stringName);
-        uint GetMemberProps(uint mb, out uint pointerClass, StringBuilder stringMember, uint cchMember, out uint pchMember, out uint pdwAttr,
+        uint GetMemberProps(uint mb, out uint pointerClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringMember, uint cchMember, out uint pchMember, out uint pdwAttr,
           out byte* ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags, out uint pdwCPlusTypeFlag, out void* ppValue);
-        uint GetFieldProps(uint mb, out uint pointerClass, StringBuilder stringField, uint cchField, out uint pchField, out uint pdwAttr,
+        uint GetFieldProps(uint mb, out uint pointerClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringField, uint cchField, out uint pchField, out uint pdwAttr,
           out byte* ppvSigBlob, out uint pcbSigBlob, out uint pdwCPlusTypeFlag, out void* ppValue);
-        uint GetPropertyProps(uint prop, out uint pointerClass, StringBuilder stringProperty, uint cchProperty, out uint pchProperty, out uint pdwPropFlags,
+        uint GetPropertyProps(uint prop, out uint pointerClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] stringProperty, uint cchProperty, out uint pchProperty, out uint pdwPropFlags,
           out byte* ppvSig, out uint bytePointerSig, out uint pdwCPlusTypeFlag, out void* ppDefaultValue, out uint pcchDefaultValue, out uint pmdSetter,
           out uint pmdGetter, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 14)] uint[] rmdOtherMethod, uint countMax);
-        uint GetParamProps(uint tk, out uint pmd, out uint pulSequence, StringBuilder stringName, uint cchName, out uint pchName,
+        uint GetParamProps(uint tk, out uint pmd, out uint pulSequence, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] char[] stringName, uint cchName, out uint pchName,
           out uint pdwAttr, out uint pdwCPlusTypeFlag, out void* ppValue);
         uint GetCustomAttributeByName(uint tokenObj, string stringName, out void* ppData);
         [PreserveSig]

--- a/src/Microsoft.DiaSymReader.PortablePdb/MetadataImport.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/MetadataImport.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
@@ -55,18 +54,18 @@ namespace Microsoft.DiaSymReader.PortablePdb
             {
                 _import.GetTypeDefProps(typeDefinition, qualifiedName: null, 0, out int nameLength, out _, out _);
 
-                var buffer = new StringBuilder(nameLength + 1);
-                _import.GetTypeDefProps(typeDefinition, buffer, buffer.Capacity, out _, out _, out _);
-                qualifiedName = buffer.ToString();
+                var buffer = new char[nameLength + 1];
+                _import.GetTypeDefProps(typeDefinition, buffer, buffer.Length, out _, out _, out _);
+                qualifiedName = new string(buffer, 0, nameLength);
             }
 
             public override void GetTypeRefProps(int typeReference, out string qualifiedName)
             {
                 _import.GetTypeRefProps(typeReference, out _, qualifiedName: null, 0, out int nameLength);
 
-                var buffer = new StringBuilder(nameLength + 1);
-                _import.GetTypeRefProps(typeReference, out _, buffer, buffer.Capacity, out _);
-                qualifiedName = buffer.ToString();
+                var buffer = new char[nameLength + 1];
+                _import.GetTypeRefProps(typeReference, out _, buffer, buffer.Length, out _);
+                qualifiedName = new string(buffer, 0, nameLength);
             }
 
             public override unsafe int GetSigFromToken(int token, out byte* signaturePtr, out int signatureLength)

--- a/src/Microsoft.DiaSymReader.PortablePdb/MethodId.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/MethodId.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public bool Equals(MethodId other) => Value == other.Value;
         public override int GetHashCode() => Value.GetHashCode();
-        public override bool Equals(object obj) => obj is MethodId id && Equals(id);
+        public override bool Equals(object? obj) => obj is MethodId id && Equals(id);
 
         public int CompareTo(MethodId other) => Value.CompareTo(other.Value);
 

--- a/src/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.csproj
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+#if NET9_0_OR_GREATER
+global using GeneratedWhenPossibleComInterfaceAttribute = System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute;
+#else
+global using GeneratedWhenPossibleComInterfaceAttribute = System.Runtime.InteropServices.ComImportAttribute;
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -9,6 +15,9 @@ using System.IO;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 [assembly: Guid("CA89ACD1-A1D5-43DE-890A-5FDF50BC1F93")]
 
@@ -16,7 +25,10 @@ namespace Microsoft.DiaSymReader.PortablePdb
 {
     [Guid("E4B18DEF-3B78-46AE-8F50-E67E421BDF70")]
     [ComVisible(true)]
-    public sealed class SymBinder : ISymUnmanagedBinder4
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymBinder : ISymUnmanagedBinder4
     {
         [PreserveSig]
         public unsafe int GetReaderForFile(

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
-#if NET9_0_OR_GREATER
-global using GeneratedWhenPossibleComInterfaceAttribute = System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute;
-#else
-global using GeneratedWhenPossibleComInterfaceAttribute = System.Runtime.InteropServices.ComImportAttribute;
-#endif
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
         }
 
         /// <summary>
-        /// Given a metadata interface and a file name, returns the 
+        /// Given a metadata interface and a file name, returns the
         /// <see cref="ISymUnmanagedReader"/> interface that will read the debugging symbols associated
         /// with the module.
         /// </summary>
@@ -63,7 +63,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
                 if (string.IsNullOrEmpty(fileName))
                     throw new ArgumentException(null, nameof(fileName));
 
-                var mdImport = MetadataImport.FromObject(metadataImport) ?? 
+                var mdImport = MetadataImport.FromObject(metadataImport) ??
                     throw new ArgumentException(null, nameof(metadataImport));
 
                 // See DIA: FLocatePdbDefault, FLocateCvFilePathHelper, FLocatePdbSymsrv, FLocateCvFilePathHelper
@@ -92,7 +92,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
                 //
                 // Each attempt checks if PDB ID matches.
                 //
-                // Search policy: all is restricted unless explicitly allowed. 
+                // Search policy: all is restricted unless explicitly allowed.
                 // After opened store to cache if CACHE* given (only the first cache?)
 
                 if (!TryReadCodeViewData(fileName, out var codeViewData, out uint stamp))
@@ -105,10 +105,10 @@ namespace Microsoft.DiaSymReader.PortablePdb
                 string pdbFileName = Path.GetFileName(codeViewData.Path);
                 var lazyImport = new LazyMetadataImport(mdImport);
 
-                // 1) next to the PE file 
+                // 1) next to the PE file
                 if ((searchPolicy & SymUnmanagedSearchPolicy.AllowReferencePathAccess) != 0)
                 {
-                    string peDirectory = Path.GetDirectoryName(fileName);
+                    string peDirectory = Path.GetDirectoryName(fileName)!;
                     string pdbFilePath = Path.Combine(peDirectory, pdbFileName);
 
                     if (TryCreateReaderForMatchingPdb(pdbFilePath, guid, stamp, age, lazyImport, out reader))
@@ -391,7 +391,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
             [MarshalAs(UnmanagedType.Interface)]object stream,
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader)
         {
-            var comStream = stream as IStream ?? 
+            var comStream = stream as IStream ??
                 throw new ArgumentException(null, nameof(stream));
 
             if (metadataImportProvider == null)

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymConstant.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymConstant.cs
@@ -8,10 +8,17 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    public sealed class SymConstant : ISymUnmanagedConstant
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymConstant : ISymUnmanagedConstant
     {
         private readonly PortablePdbReader _pdbReader;
         private readonly LocalConstantHandle _handle;

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymDocument.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymDocument.cs
@@ -6,11 +6,17 @@ using System;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    public sealed class SymDocument : ISymUnmanagedDocument
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymDocument : ISymUnmanagedDocument
     {
         private readonly static Guid s_vendorMicrosoftGuid = new("994b45c4-e6e9-11d2-903f-00c04fa302a1");
         private readonly static Guid s_documentTypeGuid = new("5a869d0b-6611-11d3-bd2a-0000f80849bd");

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymMethod.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymMethod.cs
@@ -10,11 +10,17 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    public sealed class SymMethod : ISymUnmanagedMethod2, ISymUnmanagedAsyncMethod, ISymEncUnmanagedMethod
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymMethod : ISymUnmanagedMethod2, ISymUnmanagedAsyncMethod, ISymEncUnmanagedMethod
     {
         internal MethodDebugInformationHandle DebugHandle { get; }
         internal MethodDefinitionHandle DefinitionHandle => DebugHandle.ToDefinitionHandle();

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymReader.cs
@@ -14,6 +14,9 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 using System.Threading;
 using Roslyn.Utilities;
 
@@ -23,7 +26,10 @@ namespace Microsoft.DiaSymReader.PortablePdb
     // ISymUnmanagedReaderSymbolSearchInfo?
 
     [ComVisible(false)]
-    public sealed class SymReader : ISymUnmanagedReader5, ISymUnmanagedDispose, ISymUnmanagedEncUpdate
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymReader : ISymUnmanagedReader5, ISymUnmanagedDispose, ISymUnmanagedEncUpdate
     {
         private readonly Lazy<bool> _lazyVbSemantics;
         private readonly LazyMetadataImport _metadataImport;

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymScope.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymScope.cs
@@ -4,11 +4,17 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    public sealed class SymScope : ISymUnmanagedScope2
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymScope : ISymUnmanagedScope2
     {
         internal readonly ScopeData _data;
 

--- a/src/Microsoft.DiaSymReader.PortablePdb/SymVariable.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymVariable.cs
@@ -8,11 +8,17 @@ using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
     [ComVisible(false)]
-    public sealed class SymVariable : ISymUnmanagedVariable
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    public sealed partial class SymVariable : ISymUnmanagedVariable
     {
         private const int ADDR_IL_OFFSET = 1;
 

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/EnumerableHelpers.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/EnumerableHelpers.cs
@@ -10,10 +10,10 @@ namespace Microsoft.DiaSymReader.PortablePdb
     internal static class EnumerableHelpers
     {
         /// <summary>
-        /// Groups specified entries by key optimizing for single-item groups. 
+        /// Groups specified entries by key optimizing for single-item groups.
         /// The ordering of values within each bucket is the same as their ordering in the <paramref name="entries"/> sequence.
         /// </summary>
-        public static Dictionary<K, (V Single, ImmutableArray<V> Multiple)> GroupBy<K, V>(this IEnumerable<KeyValuePair<K, V>> entries, IEqualityComparer<K> keyComparer)
+        public static Dictionary<K, (V Single, ImmutableArray<V> Multiple)> GroupBy<K, V>(this IEnumerable<KeyValuePair<K, V>> entries, IEqualityComparer<K> keyComparer) where K : notnull
         {
             var builder = new Dictionary<K, (V Single, ImmutableArray<V>.Builder? Multiple)>(keyComparer);
 

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/FileNameUtilities.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/FileNameUtilities.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
         /// <summary>
         /// Get file name from path.
         /// </summary>
-        /// <remarks>Unlike <see cref="System.IO.Path.GetFileName"/> doesn't check for invalid path characters.</remarks>
+        /// <remarks>Unlike <see cref="System.IO.Path.GetFileName(string)"/> doesn't check for invalid path characters.</remarks>
         internal static string GetFileName(string path)
         {
             int fileNameStart = IndexOfFileName(path);

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/InteropUtilities.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/InteropUtilities.cs
@@ -62,9 +62,12 @@ namespace Microsoft.DiaSymReader.PortablePdb
         {
             if (newOwner != null)
             {
-                if (obj != null && Marshal.IsComObject(obj))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    Marshal.ReleaseComObject(obj);
+                    if (obj != null && Marshal.IsComObject(obj))
+                    {
+                        Marshal.ReleaseComObject(obj);
+                    }
                 }
 
                 obj = null;

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/LazyMetadataImport.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/LazyMetadataImport.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
             {
                 Debug.Assert(_metadataImportProvider != null, "MetadataImport disposed");
 
-                var import = MetadataImport.FromObject(_metadataImportProvider.GetMetadataImport()) ?? 
+                var import = MetadataImport.FromObject(_metadataImportProvider.GetMetadataImport()) ??
                     throw new InvalidOperationException();
 
                 Interlocked.CompareExchange(ref _lazyMetadataImport, import, null);
@@ -42,9 +42,12 @@ namespace Microsoft.DiaSymReader.PortablePdb
         public void Dispose()
         {
             var import = Interlocked.Exchange(ref _lazyMetadataImport, null);
-            if (import != null && Marshal.IsComObject(import))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Marshal.ReleaseComObject(import);
+                if (import != null && Marshal.IsComObject(import))
+                {
+                    Marshal.ReleaseComObject(import);
+                }
             }
         }
     }

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/Nullable.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/Nullable.cs
@@ -2,6 +2,9 @@
 // The.NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+
+#if !NET
+
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
@@ -30,3 +33,5 @@ namespace System.Diagnostics.CodeAnalysis
         public string[] Members { get; }
     }
 }
+
+#endif

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/PortableShim.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/PortableShim.cs
@@ -41,12 +41,12 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
             internal static readonly Func<string, bool> Exists = Type
                 .GetTypeInfo()
-                .GetDeclaredMethod(nameof(Exists), new[] { typeof(string) })
+                .GetDeclaredMethod(nameof(Exists), new[] { typeof(string) })!
                 .CreateDelegate<Func<string, bool>>()!;
 
             internal static readonly Func<string, byte[]> ReadAllBytes = Type
                 .GetTypeInfo()
-                .GetDeclaredMethod(nameof(ReadAllBytes), paramTypes: new[] { typeof(string) })
+                .GetDeclaredMethod(nameof(ReadAllBytes), paramTypes: new[] { typeof(string) })!
                 .CreateDelegate<Func<string, byte[]>>()!;
         }
 

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ReadOnlyInteropStream.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ReadOnlyInteropStream.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
             {
                 const int STATFLAG_NONAME = 1;
 
-                STATSTG stats;
+                System.Runtime.InteropServices.ComTypes.STATSTG stats;
                 _stream.Stat(out stats, STATFLAG_NONAME);
                 return stats.cbSize;
             }

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ReflectionUtilities.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ReflectionUtilities.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         /// <summary>
         /// Find a <see cref="Type"/> instance by first probing the contract name and then the name as it
-        /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios. 
+        /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios.
         /// </summary>
         public static Type? GetTypeFromEither(string contractName, string desktopName)
         {
@@ -127,7 +127,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
             }
             catch (TargetInvocationException e)
             {
-                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(e.InnerException!).Throw();
                 Debug.Assert(false, "Unreachable");
                 return default;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public static T Invoke<T>(this MethodInfo methodInfo, object obj, params object[] args)
         {
-            return (T)methodInfo.Invoke(obj, args);
+            return (T)methodInfo.Invoke(obj, args)!;
         }
     }
 }

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ValueTuple.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/ValueTuple.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Numerics.Hashing;
 using System.Runtime.InteropServices;
 
+#if !NETSTANDARD2_0_OR_GREATER && !NET
+
 namespace System
 {
     internal struct ValueTuple
@@ -27,23 +29,25 @@ namespace System
             Item2 = item2;
         }
 
-        public override bool Equals(object obj) => 
+        public override bool Equals(object obj) =>
             obj is ValueTuple<T1, T2> && Equals((ValueTuple<T1, T2>)obj);
 
-        public bool Equals(ValueTuple<T1, T2> other) => 
-            EqualityComparer<T1>.Default.Equals(Item1, other.Item1) && 
+        public bool Equals(ValueTuple<T1, T2> other) =>
+            EqualityComparer<T1>.Default.Equals(Item1, other.Item1) &&
             EqualityComparer<T2>.Default.Equals(Item2, other.Item2);
 
-        internal static int CombineHashCodes(int h1, int h2) => 
+        internal static int CombineHashCodes(int h1, int h2) =>
             HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
 
-        public override int GetHashCode() => 
+        public override int GetHashCode() =>
             CombineHashCodes(Item1?.GetHashCode() ?? 0, Item2?.GetHashCode() ?? 0);
 
-        private int GetHashCodeCore(IEqualityComparer comparer) => 
+        private int GetHashCodeCore(IEqualityComparer comparer) =>
             CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2));
 
-        public override string ToString() => 
+        public override string ToString() =>
             "(" + Item1?.ToString() + ", " + Item2?.ToString() + ")";
     }
 }
+
+#endif


### PR DESCRIPTION
This drops building for netstandard 1.1 and instead multi-targets to netstandard 2.0 and net 9.0.

A major version bump was performed to 2.0.0.

Consume the 2.2.0 version of `Microsoft.DiaSymReader`.