### PR TITLE
Fix cast when stream is IUnsafeComStream

### DIFF
--- a/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/SymBinder.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using Microsoft.DiaSymReader.PortablePdb.Utilities;
+
 #if NET9_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;
 #endif
@@ -323,7 +325,13 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
             try
             {
-                var comStream = stream as IStream ?? throw new ArgumentNullException(null, nameof(stream));
+                var comStream = stream as IStream;
+                if (comStream is null)
+                {
+                    var unsafeComStream = stream as IUnsafeComStream ?? throw new ArgumentException(null, nameof(stream));
+                    comStream = new UnsafeComStreamWrapper(unsafeComStream);
+                }
+
                 var mdImport = MetadataImport.FromObject(metadataImport) ?? throw new ArgumentException(null, nameof(metadataImport));
 
                 reader = SymReader.CreateFromStream(comStream, new LazyMetadataImport(mdImport));
@@ -397,8 +405,12 @@ namespace Microsoft.DiaSymReader.PortablePdb
             [MarshalAs(UnmanagedType.Interface)]object stream,
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader)
         {
-            var comStream = stream as IStream ??
-                throw new ArgumentException(null, nameof(stream));
+            var comStream = stream as IStream;
+            if (comStream is null)
+            {
+                var unsafeComStream = stream as IUnsafeComStream ?? throw new ArgumentException(null, nameof(stream));
+                comStream = new UnsafeComStreamWrapper(unsafeComStream);
+            }
 
             if (metadataImportProvider == null)
                 throw new ArgumentException(null, nameof(metadataImportProvider));

--- a/src/Microsoft.DiaSymReader.PortablePdb/Utilities/UnsafeComStreamWrapper.cs
+++ b/src/Microsoft.DiaSymReader.PortablePdb/Utilities/UnsafeComStreamWrapper.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ComTypes;
+
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
+namespace Microsoft.DiaSymReader.PortablePdb.Utilities;
+
+/// <summary>
+/// Provides an <see cref="IStream"/>-like wrapper around an <see cref="IUnsafeComStream"/> to handle incompatibilities
+/// introduced with source-generated ComWrappers.
+/// </summary>
+/// <remarks>
+/// <see cref="ComStreamWrapper"/> is a wrapper around a <see cref="Stream"/> that implements both interface definitions.
+/// This is a wrapper around a marshalled <see cref="IUnsafeComStream"/> that also implements the <see cref="IStream"/> interface."/>
+/// </remarks>
+#if NET9_0_OR_GREATER
+[GeneratedComClass]
+#endif
+internal partial class UnsafeComStreamWrapper : IUnsafeComStream, IStream
+{
+    private readonly IUnsafeComStream _stream;
+
+    public UnsafeComStreamWrapper(IUnsafeComStream stream)
+    {
+        _stream = stream;
+    }
+
+    #region IUnsafeComStream
+
+    public unsafe void Read(byte* pv, int cb, int* pcbRead) => _stream.Read(pv, cb, pcbRead);
+
+    public unsafe void Write(byte* pv, int cb, int* pcbWritten) => _stream.Write(pv, cb, pcbWritten);
+
+    public unsafe void Seek(long dlibMove, int dwOrigin, long* plibNewPosition) => _stream.Seek(dlibMove, dwOrigin, plibNewPosition);
+
+    public void SetSize(long libNewSize) => _stream.SetSize(libNewSize);
+
+    public unsafe void CopyTo(IntPtr pstm, long cb, int* pcbRead, int* pcbWritten) => _stream.CopyTo(pstm, cb, pcbRead, pcbWritten);
+
+    public void Commit(int grfCommitFlags) => _stream.Commit(grfCommitFlags);
+
+    public void Revert() => _stream.Revert();
+
+    public void LockRegion(long libOffset, long cb, int dwLockType) => _stream.LockRegion(libOffset, cb, dwLockType);
+
+    public void UnlockRegion(long libOffset, long cb, int dwLockType) => _stream.UnlockRegion(libOffset, cb, dwLockType);
+
+    public void Stat(out STATSTG pstatstg, int grfStatFlag) => _stream.Stat(out pstatstg, grfStatFlag);
+
+    public void Clone(out IntPtr ppstm) => _stream.Clone(out ppstm);
+
+    #endregion
+
+    #region IStream
+
+    public void Clone(out IStream ppstm) => throw new NotSupportedException("Clone is not supported in this version.");
+
+    public void CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten) => throw new NotImplementedException("CopyTo is not implemented in this version.");
+
+    public unsafe void Read(byte[] pv, int cb, IntPtr pcbRead) => _stream.Read((byte*)Unsafe.AsPointer(ref pv[0]), cb, (int*)pcbRead);
+
+    public unsafe void Seek(long dlibMove, int dwOrigin, IntPtr plibNewPosition) => _stream.Seek(dlibMove, dwOrigin, (long*)plibNewPosition);
+
+    public unsafe void Write(byte[] pv, int cb, IntPtr pcbWritten) => _stream.Write((byte*)Unsafe.AsPointer(ref pv[0]), cb, (int*)pcbWritten);
+
+    void System.Runtime.InteropServices.ComTypes.IStream.Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)
+    {
+        _stream.Stat(out var unsafeSTASTG, grfStatFlag);
+
+        pstatstg = new System.Runtime.InteropServices.ComTypes.STATSTG()
+        {
+            cbSize = unsafeSTASTG.cbSize,
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
The switch to ComWrappers meant that marshalling parameters such as `stream` in 
```