### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -31,12 +31,13 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
+      publishingVersion: 4
       enableTelemetry: true
       enableSourceBuild: false
       helixRepo: dotnet/symreader
       jobs:
       - job: Windows
+        enablePublishing: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             vmImage: 'windows-latest'
@@ -51,7 +52,7 @@ stages:
           - name: _OfficialBuildArgs
             value: /p:DotNetSignType=$(_SignType)
                    /p:TeamName=$(_TeamName)                   
-                   /p:DotNetPublishUsingPipelines=true
+                  
                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         # else
         - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -131,7 +132,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
-      publishingInfraVersion: 3
+      publishingInfraVersion: 4
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,12 +73,13 @@ extends:
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           enableTelemetry: true
           enableSourceBuild: false
           helixRepo: dotnet/symreader
           jobs:
           - job: Windows
+            enablePublishing: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
             pool:
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
                 vmImage: 'windows-latest'
@@ -89,7 +90,7 @@ extends:
             - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               - group: Publish-Build-Assets
               - name: _OfficialBuildArgs
-                value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               - name: _OfficialBuildArgs
                 value: ''
@@ -162,5 +163,5 @@ extends:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,6 +2,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles