### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,6 @@ extends:
                 demands: ImageOverride -equals 1es-windows-2022
             variables:
             - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              - group: Publish-Build-Assets
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131